### PR TITLE
Adds config file information on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,16 @@ Flags:
       --password string   RCON server's password
       --port int          Server's RCON port (default 27015)
 ```
+
+## Configuration
+
+You can preconfigure rcon-cli to use the arguments you want by default by modifying the file `.rcon-cli.yaml` in your home folder. If you want to use any other file use the argument `--config /path/to/the/config.yaml`. 
+
+Example of a `.rcon-cli.yaml` file:
+```yaml
+host: mydomain.com
+port: 12345
+password: mycustompassword
+```
+
+That way executing `rcon-cli` without arguments would connect to `mydomain.com:12345` with the password `mycustompassword` by default.


### PR DESCRIPTION
I had to guess the syntax of the yaml used to config rcon-cli. I'm only using the tool to rcon to my personal minecraft server (using your docker image! thanks for that!).

I think this info does matter for some people so adding it to the readme seems like a good idea :)