### PR TITLE
Use ENTRYPOINT exec form instead of shell form

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
 COPY rcon-cli /
-ENTRYPOINT /rcon-cli
+ENTRYPOINT ["/rcon-cli"]


### PR DESCRIPTION
The image has no shell at `/bin/sh` so the `ENTRYPOINT` _shell_ form does not work:
```
$ docker run --rm itzg/rcon-cli:1.4.7 --help
Unable to find image 'itzg/rcon-cli:1.4.7' locally
1.4.7: Pulling from itzg/rcon-cli
8839a1e05eed: Pull complete
Digest: sha256:8470c29d26d7abc1475d2adc4b5e5a6f746a788763f511757bf179c39e3f26c9
Status: Downloaded newer image for itzg/rcon-cli:1.4.7
docker: Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/bin/sh\": stat /bin/sh: no such file or directory": unknown.
```
```
$ GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o rcon-cli .
$ docker build -t rcon-cli .
Sending build context to Docker daemon   12.2MB
Step 1/3 : FROM scratch
 --->
Step 2/3 : COPY rcon-cli /
 ---> 0dd2badd83fe
Step 3/3 : ENTRYPOINT /rcon-cli
 ---> Running in d81dcc3f9b4c
Removing intermediate container d81dcc3f9b4c
 ---> 327b6d337275
Successfully built 327b6d337275
Successfully tagged rcon-cli:latest
$ docker run --rm rcon-cli --help
docker: Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/bin/sh\": stat /bin/sh: no such file or directory": unknown.
```

You can work around it by overriding the `ENTRYPOINT` of the image:
```
$ docker run --rm --entrypoint /rcon-cli itzg/rcon-cli:1.4.7 --help

rcon-cli is a CLI for attaching to an RCON enabled game server, such as Minecraft.
Without any additional arguments, the CLI will start an interactive session with
the RCON server.

...
```

Using the `ENTRYPOINT` _exec_ form instead (i.e. `ENTRYPOINT ["/rcon-cli"]`) makes it work out of the box:
```
$ GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o rcon-cli .
$ docker build -t rcon-cli .
Sending build context to Docker daemon   12.2MB
Step 1/3 : FROM scratch
 --->
Step 2/3 : COPY rcon-cli /
 ---> Using cache
 ---> 0dd2badd83fe
Step 3/3 : ENTRYPOINT [ "/rcon-cli" ]
 ---> Running in a96eb138ebf7
Removing intermediate container a96eb138ebf7
 ---> d649b44a2dca
Successfully built d649b44a2dca
Successfully tagged rcon-cli:latest
$ docker run --rm rcon-cli --help

rcon-cli is a CLI for attaching to an RCON enabled game server, such as Minecraft.
Without any additional arguments, the CLI will start an interactive session with
the RCON server.

...
```