### PR TITLE
build: upgrade Go to 1.20.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     uses: itzg/github-workflows/.github/workflows/go-with-releaser-image.yml@main
     with:
-      go-version: "1.21.10"
+      go-version: "1.21.11"
     secrets:
       image-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       image-registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,4 @@ jobs:
   build:
     uses: itzg/github-workflows/.github/workflows/go-test.yml@main
     with:
-      go-version: "1.21.10"
+      go-version: "1.21.11"


### PR DESCRIPTION
Fix

```
/usr/local/bin/rcon-cli (evident by)

    x HIGH CVE-2023-45283
      https://scout.docker.com/v/CVE-2023-45283
      Affected range : <1.20.11
      Fixed version  : 1.20.11
```