### PR TITLE
build: upgrade to Go 1.22.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     uses: itzg/github-workflows/.github/workflows/go-with-releaser-image.yml@main
     with:
-      go-version: "1.22.5"
+      go-version: "1.22.7"
     secrets:
       image-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       image-registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,4 @@ jobs:
   build:
     uses: itzg/github-workflows/.github/workflows/go-test.yml@main
     with:
-      go-version: "1.22.5"
+      go-version: "1.22.7"


### PR DESCRIPTION
    ✗ HIGH CVE-2024-34158
      https://scout.docker.com/v/CVE-2024-34158
      Affected range : <1.22.7
      Fixed version  : 1.22.7

    ✗ HIGH CVE-2024-34156
      https://scout.docker.com/v/CVE-2024-34156
      Affected range : <1.22.7
      Fixed version  : 1.22.7

    ✗ HIGH CVE-2022-30635
      https://scout.docker.com/v/CVE-2022-30635
      Affected range : <1.22.7
      Fixed version  : 1.22.7