### PR TITLE
docs: explain "exit" keyword for interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you [have Go](https://golang.org/dl/) you could also simply `go get github.co
 ```text
 rcon-cli is a CLI for attaching to an RCON enabled game server, such as Minecraft.
 Without any additional arguments, the CLI will start an interactive session with
-the RCON server.
+the RCON server. Send the keyword "exit" to close the session. The CLI will exit.
 
 If arguments are passed into the CLI, then the arguments are sent
 as a single command (joined by spaces), the response is displayed,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,7 @@ RCON_PORT=25575 rcon-cli stop
 	Long: `
 rcon-cli is a CLI for attaching to an RCON enabled game server, such as Minecraft.
 Without any additional arguments, the CLI will start an interactive session with
-the RCON server.
+the RCON server. Send the keyword "exit" to close the session. The CLI will exit.
 
 If arguments are passed into the CLI, then the arguments are sent
 as a single command (joined by spaces), the response is displayed,


### PR DESCRIPTION
Closes #76

Adds documentation to the README and the CLI's long help text to explain that users can end an interactive session by sending the keyword "exit"