### PR TITLE
version bump go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/itzg/rcon-cli
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/james4k/rcon v0.0.0-20210222224819-34a67ca2b2d6


### PR DESCRIPTION
Build failed on go version (CVE)